### PR TITLE
specify path sep in manisfest, closes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ BagIt.prototype.createWriteStream = function (name, opts) {
     function (cb) {
       hash = digest.digest('hex')
       // TODO: check if old file hash is in manifest
-      var data = `${hash} ${path.relative(self.dir, name)}\n`
+      var data = `${hash} ${path.relative(self.dir, name).split(path.sep).join('/')}\n`
       fs.appendFile(self.manifest, data, cb)
     }
   )


### PR DESCRIPTION
bagit requires `/` to be used as the path separator so we need to replace the windows path separator before writing file path to manifest.